### PR TITLE
chore: rename project to open-discogs-batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Docker and external network access.
 The executable is written to:
 
 ```text
-build/libs/discogs-batch-0.1.8.jar
+build/libs/open-discogs-batch-0.1.8.jar
 ```
 
 ## Run
@@ -73,7 +73,7 @@ build/libs/discogs-batch-0.1.8.jar
 The database URL, username, and password are required. For example:
 
 ```bash
-java -jar build/libs/discogs-batch-0.1.8.jar \
+java -jar build/libs/open-discogs-batch-0.1.8.jar \
   --url=jdbc:postgresql://localhost:5432/discogs \
   --username=<database-user> \
   --password=<database-password> \

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ jacocoTestReport {
 }
 
 bootBuildImage {
-    setImageName('sehy0121/discogs-batch-0.1.8')
+    setImageName("open-discogs-batch:${project.version}")
 }
 // disable caching
 configurations.each {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'discogs-batch'
-
+rootProject.name = 'open-discogs-batch'


### PR DESCRIPTION
## What changed

- rename the Gradle project to `open-discogs-batch`
- update executable JAR paths in the README
- rename the local Spring Boot image to `open-discogs-batch:<version>`

## Why

The repository has moved to `dsub-io/open-discogs-batch`, and its build outputs should use the same independent OpenDiscogs identity.

## Impact

Java package names and the Spring Batch job name are unchanged. The executable JAR and locally built container image use the new project name.

## Checks

- `git diff --check`
- `./gradlew clean assemble --no-daemon` using Eclipse Temurin 16
- verified `build/libs/open-discogs-batch-0.1.8.jar` exists and the legacy JAR name does not
