### PR TITLE
refactor: remove JPA and establish test gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build, test, and coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: temurin
+          java-version: 16
+          cache: gradle
+      - name: Run deterministic tests and coverage gate
+        run: ./gradlew clean check --no-daemon

--- a/README.md
+++ b/README.md
@@ -52,15 +52,30 @@ Build the executable JAR:
 ./gradlew clean assemble
 ```
 
-Run the complete test suite:
+Run the deterministic unit and integration suite, generate the coverage report,
+and enforce the coverage gate:
 
 ```bash
-./gradlew clean test
+./gradlew clean check
 ```
 
-Some integration tests start PostgreSQL through Testcontainers, and some
-exercise the live dump index at `data.discogs.com`. They therefore require
-Docker and external network access.
+Integration tests start PostgreSQL through Testcontainers and therefore require
+Docker. Tests that access `data.discogs.com` are kept outside the deterministic
+suite and can be run explicitly:
+
+```bash
+./gradlew e2eTest
+```
+
+Executable test classes use one of three suffixes:
+
+- `*UnitTest` for isolated tests.
+- `*IntegrationTest` for deterministic component and Testcontainers tests.
+- `*E2ETest` for opt-in end-to-end checks against external services.
+
+The build rejects other executable test class names. Pull requests must pass
+the deterministic suite and maintain at least 85% line coverage and 40% branch
+coverage.
 
 The executable is written to:
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,7 @@ ext {
     set('testcontainersVersion', "1.21.4")
     set('springOxmVersion', "5.3.8")
     set('jaxbApiVersion', "2.3.1")
-    set('jaxbImplVersion', "3.0.1")
-    set('istackCommonsRuntimeVersion', "4.0.1")
+    set('jaxbRuntimeVersion', "2.3.8")
     set('classGraphVersion', "4.8.108")
     set('pbVersion', "0.9.1")
     set('openDiscogsJooqVersion', "0.0.4")
@@ -48,14 +47,12 @@ dependencies {
     implementation(
             'com.fasterxml.jackson.datatype:jackson-datatype-jsr310',
             'org.springframework.boot:spring-boot-starter-batch',
-            'org.springframework.boot:spring-boot-starter-data-jpa',
             'org.springframework.batch:spring-batch-integration',
             'org.springframework.boot:spring-boot-starter-jooq',
             "io.dsub.opendiscogs:open-discogs-jooq:${openDiscogsJooqVersion}",
             "org.springframework:spring-oxm:${springOxmVersion}",
             "javax.xml.bind:jaxb-api:${jaxbApiVersion}",
-            "com.sun.xml.bind:jaxb-impl:${jaxbImplVersion}",
-            "com.sun.istack:istack-commons-runtime:${istackCommonsRuntimeVersion}",
+            "org.glassfish.jaxb:jaxb-runtime:${jaxbRuntimeVersion}",
             "io.github.classgraph:classgraph:${classGraphVersion}",
             "me.tongfei:progressbar:${pbVersion}",
             "org.liquibase:liquibase-core:${liquibaseVersion}",
@@ -82,16 +79,71 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'e2e'
+    }
 }
 
-// coverage
+tasks.register('e2eTest', Test) {
+    description = 'Runs tests that access live external services.'
+    group = 'verification'
+    useJUnitPlatform {
+        includeTags 'e2e'
+    }
+    shouldRunAfter test
+}
+
+tasks.register('validateTestNaming') {
+    description = 'Checks executable test classes use a recognized test suffix.'
+    group = 'verification'
+    def testSources = fileTree('src/test/java') {
+        include '**/*.java'
+    }
+    inputs.files(testSources)
+    doLast {
+        def invalidFiles = testSources.findAll { file ->
+            def source = file.getText('UTF-8')
+            def containsTests =
+                    source =~ /@(Test|ParameterizedTest|RepeatedTest|TestFactory)\b/
+            containsTests && !(file.name ==~ /.*(UnitTest|IntegrationTest|E2ETest)\.java/)
+        }
+        if (!invalidFiles.isEmpty()) {
+            def names = invalidFiles.collect {
+                project.relativePath(it)
+            }.sort().join('\n - ')
+            throw new GradleException(
+                    "Test classes must end in UnitTest, IntegrationTest, or E2ETest:\n - ${names}")
+        }
+    }
+}
+
+check.dependsOn validateTestNaming
 check.dependsOn jacocoTestReport
+check.dependsOn jacocoTestCoverageVerification
 
 jacocoTestReport {
+    dependsOn test
     reports {
         xml.enabled true
-        html.enabled false
+        html.enabled true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.85
+            }
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.40
+            }
+        }
     }
 }
 

--- a/src/main/java/io/dsub/discogs/batch/BatchApplication.java
+++ b/src/main/java/io/dsub/discogs/batch/BatchApplication.java
@@ -2,12 +2,11 @@ package io.dsub.discogs.batch;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
 @Slf4j
-@SpringBootApplication(exclude = {HibernateJpaAutoConfiguration.class})
+@SpringBootApplication
 public class BatchApplication {
 
   private static ConfigurableApplicationContext APP_CONTEXT;

--- a/src/main/java/io/dsub/discogs/batch/dump/DefaultDumpSupplier.java
+++ b/src/main/java/io/dsub/discogs/batch/dump/DefaultDumpSupplier.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -22,8 +23,6 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -109,19 +108,18 @@ public class DefaultDumpSupplier implements DumpSupplier {
    * @return bucket url if success, else return null.
    */
   protected String getBucketURL() {
-    Stream<String> resultStream;
     int retryCount = 0;
     String bucketURL = null;
 
-    while (retryCount < 3 && bucketURL == null) { // retry future.get() method three times max.
-      try {
-        resultStream = getDiscogsDataSourceStream();
+    while (retryCount < 3 && bucketURL == null) {
+      retryCount++;
+      try (Stream<String> resultStream = getDiscogsDataSourceStream()) {
         AtomicReference<String> bucketUrlRef = new AtomicReference<>();
         resultStream
             .map(String::trim)
             .filter(s -> BUCKET_VAR_DECLARATION_PATTERN.matcher(s).matches())
             .findFirst()
-            .ifPresent( // we found something that
+            .ifPresent(
                 s -> {
                   s = StringUtils.trimAllWhitespace(s);
                   String fin = s.substring(s.indexOf('\'') + 1, s.lastIndexOf('\''));
@@ -134,26 +132,27 @@ public class DefaultDumpSupplier implements DumpSupplier {
                 });
         // get referenced value.
         bucketURL = bucketUrlRef.get();
-      } catch (ExecutionException | InterruptedException e) {
-        retryCount++;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      } catch (IOException e) {
+        log.warn("failed to resolve the Discogs data bucket URL", e);
       }
     }
     return bucketURL;
   }
 
   protected Stream<String> getDiscogsDataSourceStream()
-      throws ExecutionException, InterruptedException {
-    HttpClient client = HttpClient.newBuilder().build();
-
-    // make GET request to
-    CompletableFuture<HttpResponse<Stream<String>>> future =
-        client.sendAsync(
-            HttpRequest.newBuilder().uri(URI.create(DISCOGS_DATA_URL)).GET().build(),
-            HttpResponse.BodyHandlers.ofLines());
-    while (!future.isDone()) {
-      Thread.onSpinWait();
-    }
-    return future.get().body();
+      throws IOException, InterruptedException {
+    HttpClient client =
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(DISCOGS_DATA_URL))
+            .timeout(Duration.ofSeconds(10))
+            .GET()
+            .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofLines()).body();
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,18 +12,6 @@ spring:
   batch:
     job:
       enabled: false
-  jpa:
-    properties:
-      hibernate:
-        jdbc:
-          batch_size: 500
-          time_zone: UTC
-          batch_versioned_data: true
-        order_updates: true
-        order_inserts: true
-        format_sql: true
-    hibernate:
-      ddl-auto: update
   jmx:
     enabled: false
 logging:
@@ -35,7 +23,6 @@ logging:
     org:
       reflections: ERROR
       springframework: ERROR
-      hibernate: ERROR
     com.zaxxer.hikari: ERROR
 server:
   shutdown: graceful

--- a/src/test/java/io/dsub/discogs/batch/BatchApplicationUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/BatchApplicationUnitTest.java
@@ -21,7 +21,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-class BatchApplicationTest {
+class BatchApplicationUnitTest {
 
   @Mock
   BatchService batchService;

--- a/src/test/java/io/dsub/discogs/batch/BatchServiceUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/BatchServiceUnitTest.java
@@ -26,7 +26,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
-class BatchServiceTest {
+class BatchServiceUnitTest {
 
   BatchService batchService;
 

--- a/src/test/java/io/dsub/discogs/batch/JobLaunchingRunnerUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/JobLaunchingRunnerUnitTest.java
@@ -34,7 +34,7 @@ import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
-class JobLaunchingRunnerTest {
+class JobLaunchingRunnerUnitTest {
 
   @Mock
   Job job;

--- a/src/test/java/io/dsub/discogs/batch/JobPreparationRunnerUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/JobPreparationRunnerUnitTest.java
@@ -29,7 +29,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-class JobPreparationRunnerTest {
+class JobPreparationRunnerUnitTest {
 
   @Mock
   ApplicationArguments args;

--- a/src/test/java/io/dsub/discogs/batch/argument/formatter/JdbcUrlFormatterUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/argument/formatter/JdbcUrlFormatterUnitTest.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JdbcUrlFormatterTest {
+public class JdbcUrlFormatterUnitTest {
 
   JdbcUrlFormatter formatter = new JdbcUrlFormatter();
 

--- a/src/test/java/io/dsub/discogs/batch/argument/handler/DefaultArgumentHandlerIntegrationTest.java
+++ b/src/test/java/io/dsub/discogs/batch/argument/handler/DefaultArgumentHandlerIntegrationTest.java
@@ -2,14 +2,14 @@ package io.dsub.discogs.batch.argument.handler;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.dsub.discogs.batch.container.PostgreSQLContainerBaseTest;
+import io.dsub.discogs.batch.container.PostgreSQLIntegrationSupport;
 import io.dsub.discogs.batch.exception.InvalidArgumentException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class DefaultArgumentHandlerIntegrationTest extends PostgreSQLContainerBaseTest {
+class DefaultArgumentHandlerIntegrationTest extends PostgreSQLIntegrationSupport {
 
   private final ArgumentHandler handler = new DefaultArgumentHandler();
 

--- a/src/test/java/io/dsub/discogs/batch/argument/validator/TypeArgumentValidatorUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/argument/validator/TypeArgumentValidatorUnitTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.DefaultApplicationArguments;
 
-class TypeArgumentValidatorTest {
+class TypeArgumentValidatorUnitTest {
 
   final TypeArgumentValidator validator = new TypeArgumentValidator();
 

--- a/src/test/java/io/dsub/discogs/batch/condition/RequiresDiscogsDataConnection.java
+++ b/src/test/java/io/dsub/discogs/batch/condition/RequiresDiscogsDataConnection.java
@@ -21,6 +21,8 @@ public class RequiresDiscogsDataConnection implements ExecutionCondition {
     try {
       final URL url = new URL(DISCOGS_DATA_URL);
       final URLConnection conn = url.openConnection();
+      conn.setConnectTimeout(5000);
+      conn.setReadTimeout(5000);
       conn.connect();
       in = conn.getInputStream();
     } catch (MalformedURLException e) {

--- a/src/test/java/io/dsub/discogs/batch/config/TaskExecutorConfigUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/config/TaskExecutorConfigUnitTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import oshi.SystemInfo;
 
-class TaskExecutorConfigTest {
+class TaskExecutorConfigUnitTest {
 
   ApplicationContextRunner ctx;
 

--- a/src/test/java/io/dsub/discogs/batch/container/PostgreSQLIntegrationSupport.java
+++ b/src/test/java/io/dsub/discogs/batch/container/PostgreSQLIntegrationSupport.java
@@ -7,13 +7,13 @@ import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-public abstract class PostgreSQLContainerBaseTest {
+public abstract class PostgreSQLIntegrationSupport {
 
   protected static final PostgreSQLContainer CONTAINER;
   protected static final DataSource dataSource;
 
   static {
-    CONTAINER = new PostgreSQLContainer("postgres:latest")
+    CONTAINER = new PostgreSQLContainer("postgres:16.13-alpine")
         .withDatabaseName("databaseName")
         .withPassword("password")
         .withUsername("username");

--- a/src/test/java/io/dsub/discogs/batch/datasource/DBTypeUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/datasource/DBTypeUnitTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-class DBTypeTest {
+class DBTypeUnitTest {
 
   @EnumSource(value = DBType.class)
   @ParameterizedTest

--- a/src/test/java/io/dsub/discogs/batch/dump/DefaultDumpSupplierE2ETest.java
+++ b/src/test/java/io/dsub/discogs/batch/dump/DefaultDumpSupplierE2ETest.java
@@ -1,0 +1,44 @@
+package io.dsub.discogs.batch.dump;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dsub.discogs.batch.condition.RequiresDiscogsDataConnection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("e2e")
+@ExtendWith(RequiresDiscogsDataConnection.class)
+class DefaultDumpSupplierE2ETest {
+
+  DefaultDumpSupplier dumpSupplier;
+
+  @BeforeEach
+  void setUp() {
+    dumpSupplier = new DefaultDumpSupplier();
+  }
+
+  @Test
+  void whenGet__ThenReturnsNotEmptyListOfValidDiscogsDumps() {
+    List<DiscogsDump> foundList = dumpSupplier.get();
+
+    assertThat(foundList).isNotNull().isNotEmpty();
+    foundList.forEach(
+        item ->
+            assertThat(item)
+                .satisfies(dump -> assertThat(dump.getETag()).isNotNull().isNotBlank())
+                .satisfies(dump -> assertThat(dump.getSize()).isNotNull().isGreaterThan(0))
+                .satisfies(dump -> assertThat(dump.getUriString()).isNotNull().isNotBlank())
+                .satisfies(dump -> assertThat(dump.getFileName()).matches("^[\\w_]+.xml.gz$"))
+                .satisfies(dump -> assertThat(dump.getType()).isNotNull()));
+  }
+
+  @Test
+  void whenGetBucketURL__ReturnsValidURL() {
+    String url = dumpSupplier.getBucketURL();
+
+    assertThat(url).isNotNull().isNotBlank().matches("^https://[\\w_.-]+[\\w_-].com$");
+  }
+}

--- a/src/test/java/io/dsub/discogs/batch/dump/DefaultDumpSupplierUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/dump/DefaultDumpSupplierUnitTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 
-import io.dsub.discogs.batch.condition.RequiresDiscogsDataConnection;
 import io.dsub.discogs.batch.exception.InvalidArgumentException;
 import io.dsub.discogs.batch.testutil.LogSpy;
 import java.io.File;
@@ -26,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.springframework.util.ResourceUtils;
@@ -36,7 +34,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 @Slf4j
-@ExtendWith(RequiresDiscogsDataConnection.class)
 class DefaultDumpSupplierUnitTest {
 
   @RegisterExtension
@@ -46,35 +43,6 @@ class DefaultDumpSupplierUnitTest {
   @BeforeEach
   void setUp() {
     dumpSupplier = Mockito.spy(new DefaultDumpSupplier());
-  }
-
-  @Test
-  void whenGet__ThenReturnsNotEmptyListOfValidDiscogsDumps() {
-    // when
-    List<DiscogsDump> foundList = dumpSupplier.get();
-
-    // then
-    assertThat(dumpSupplier.get())
-        .isNotNull()
-        .satisfies(list -> assertThat(list.size()).isGreaterThan(0));
-
-    foundList.forEach(
-        item ->
-            assertThat(item)
-                .satisfies(dump -> assertThat(dump.getETag()).isNotNull().isNotBlank())
-                .satisfies(dump -> assertThat(dump.getSize()).isNotNull().isGreaterThan(0))
-                .satisfies(dump -> assertThat(dump.getUriString()).isNotNull().isNotBlank())
-                .satisfies(dump -> assertThat(dump.getFileName()).matches("^[\\w_]+.xml.gz$"))
-                .satisfies(dump -> assertThat(dump.getType()).isNotNull()));
-  }
-
-  @Test
-  void whenGetBucketURL__ReturnsValidURL() {
-    // when
-    String url = dumpSupplier.getBucketURL();
-
-    // then
-    assertThat(url).isNotNull().isNotBlank().matches("^https://[\\w_.-]+[\\w_-].com$");
   }
 
   @Test

--- a/src/test/java/io/dsub/discogs/batch/dump/repository/DiscogsDumpRepositoryE2ETest.java
+++ b/src/test/java/io/dsub/discogs/batch/dump/repository/DiscogsDumpRepositoryE2ETest.java
@@ -10,13 +10,15 @@ import io.dsub.discogs.batch.dump.DumpSupplier;
 import io.dsub.discogs.batch.dump.EntityType;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+@Tag("e2e")
 @ExtendWith(RequiresDiscogsDataConnection.class)
-class DiscogsDiscogsDumpRepositoryIntegrationTest {
+class DiscogsDumpRepositoryE2ETest {
 
   static DumpSupplier dumpSupplier;
   static DiscogsDumpRepository repository;

--- a/src/test/java/io/dsub/discogs/batch/dump/service/DefaultDiscogsDumpServiceIntegrationTest.java
+++ b/src/test/java/io/dsub/discogs/batch/dump/service/DefaultDiscogsDumpServiceIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-import io.dsub.discogs.batch.condition.RequiresDiscogsDataConnection;
 import io.dsub.discogs.batch.dump.DefaultDumpSupplier;
 import io.dsub.discogs.batch.dump.DiscogsDump;
 import io.dsub.discogs.batch.dump.DumpSupplier;
@@ -18,20 +17,14 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import org.springframework.util.ResourceUtils;
 
-@ExtendWith(RequiresDiscogsDataConnection.class)
 public class DefaultDiscogsDumpServiceIntegrationTest {
 
-  final List<DiscogsDump> sampleDumpList =
-      new DefaultDumpSupplier().get().stream()
-          .sorted(DiscogsDump::compareTo)
-          .skip(200)
-          .limit(10)
-          .collect(Collectors.toList());
+  List<DiscogsDump> sampleDumpList;
 
   DumpSupplier dumpSupplier;
   DiscogsDumpRepository repository;
@@ -39,6 +32,11 @@ public class DefaultDiscogsDumpServiceIntegrationTest {
 
   @BeforeEach
   void setUp() throws Exception {
+    sampleDumpList =
+        new DefaultDumpSupplier()
+            .get(ResourceUtils.getFile("classpath:test/DiscogsDataDump.xml")).stream()
+            .sorted(DiscogsDump::compareTo)
+            .collect(Collectors.toList());
     dumpSupplier = Mockito.mock(DumpSupplier.class);
     when(dumpSupplier.get()).thenReturn(sampleDumpList);
     repository = new MapDiscogsDumpRepository(dumpSupplier);

--- a/src/test/java/io/dsub/discogs/batch/job/BatchInfrastructureConfigUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/BatchInfrastructureConfigUnitTest.java
@@ -18,7 +18,7 @@ import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-public class BatchInfrastructureConfigTest {
+public class BatchInfrastructureConfigUnitTest {
 
   ApplicationContextRunner ctx;
 

--- a/src/test/java/io/dsub/discogs/batch/job/DefaultJobParameterResolverUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/DefaultJobParameterResolverUnitTest.java
@@ -28,7 +28,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.DefaultApplicationArguments;
 
-class DefaultJobParameterResolverTest {
+class DefaultJobParameterResolverUnitTest {
 
   @RegisterExtension
   LogSpy logSpy = new LogSpy();

--- a/src/test/java/io/dsub/discogs/batch/job/PostgreSQLIntegrationTestConfig.java
+++ b/src/test/java/io/dsub/discogs/batch/job/PostgreSQLIntegrationTestConfig.java
@@ -1,6 +1,6 @@
 package io.dsub.discogs.batch.job;
 
-import io.dsub.discogs.batch.container.PostgreSQLContainerBaseTest;
+import io.dsub.discogs.batch.container.PostgreSQLIntegrationSupport;
 import javax.sql.DataSource;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.DefaultApplicationArguments;
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class PostgreSQLIntegrationTestConfig extends PostgreSQLContainerBaseTest {
+public class PostgreSQLIntegrationTestConfig extends PostgreSQLIntegrationSupport {
 
   @Bean
   public DataSource dataSource() {

--- a/src/test/java/io/dsub/discogs/batch/job/listener/ItemCountingItemProcessListenerUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/listener/ItemCountingItemProcessListenerUnitTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-class ItemCountingItemProcessListenerTest {
+class ItemCountingItemProcessListenerUnitTest {
 
   private ItemCountingItemProcessListener listener;
   private AtomicLong counter;

--- a/src/test/java/io/dsub/discogs/batch/job/reader/DumpItemReaderBuilderUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/reader/DumpItemReaderBuilderUnitTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-class DumpItemReaderBuilderTest {
+class DumpItemReaderBuilderUnitTest {
 
   DiscogsDump dump;
   FileUtil fileUtil;

--- a/src/test/java/io/dsub/discogs/batch/job/reader/ProgressBarStaxEventItemReaderUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/reader/ProgressBarStaxEventItemReaderUnitTest.java
@@ -26,7 +26,7 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.xml.StaxEventItemReader;
 
-class ProgressBarStaxEventItemReaderTest {
+class ProgressBarStaxEventItemReaderUnitTest {
 
   private final PrintStream stdout = System.out;
   private ByteArrayOutputStream outCaptor;

--- a/src/test/java/io/dsub/discogs/batch/job/step/AbstractStepConfigUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/step/AbstractStepConfigUnitTest.java
@@ -22,7 +22,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.job.flow.FlowExecutionStatus;
 import org.springframework.batch.core.job.flow.JobExecutionDecider;
 
-class AbstractStepConfigTest {
+class AbstractStepConfigUnitTest {
 
   AbstractStepConfig stepConfig;
 

--- a/src/test/java/io/dsub/discogs/batch/job/tasklet/FileClearTaskletUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/tasklet/FileClearTaskletUnitTest.java
@@ -21,7 +21,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.scope.context.StepContext;
 
-class FileClearTaskletTest {
+class FileClearTaskletUnitTest {
 
   final StepExecution stepExecution = new StepExecution("step", new JobExecution(1L));
   final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));

--- a/src/test/java/io/dsub/discogs/batch/job/tasklet/FileFetchTaskletUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/job/tasklet/FileFetchTaskletUnitTest.java
@@ -36,7 +36,7 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.repeat.RepeatStatus;
 
 @Slf4j
-class FileFetchTaskletTest {
+class FileFetchTaskletUnitTest {
 
   @Mock
   ChunkContext chunkContext;

--- a/src/test/java/io/dsub/discogs/batch/service/DefaultDatabaseConnectionValidatorIntegrationTest.java
+++ b/src/test/java/io/dsub/discogs/batch/service/DefaultDatabaseConnectionValidatorIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.dsub.discogs.batch.argument.validator.DatabaseConnectionValidator;
 import io.dsub.discogs.batch.argument.validator.DefaultDatabaseConnectionValidator;
 import io.dsub.discogs.batch.argument.validator.ValidationResult;
-import io.dsub.discogs.batch.container.PostgreSQLContainerBaseTest;
+import io.dsub.discogs.batch.container.PostgreSQLIntegrationSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ public class DefaultDatabaseConnectionValidatorIntegrationTest {
   static final DatabaseConnectionValidator service = new DefaultDatabaseConnectionValidator();
 
   @Nested
-  class PostgreSQLIntegrationTest extends PostgreSQLContainerBaseTest {
+  class PostgreSQLIntegrationTest extends PostgreSQLIntegrationSupport {
 
     @Test
     void shouldPassIfCredentialsMatch() {

--- a/src/test/java/io/dsub/discogs/batch/util/DefaultMalformedDateParserUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/util/DefaultMalformedDateParserUnitTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class DefaultMalformedDateParserTest {
+class DefaultMalformedDateParserUnitTest {
 
   DefaultMalformedDateParser parser = new DefaultMalformedDateParser();
 

--- a/src/test/java/io/dsub/discogs/batch/util/ReflectionUtilUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/util/ReflectionUtilUnitTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @Slf4j
-class ReflectionUtilTest {
+class ReflectionUtilUnitTest {
 
   @RegisterExtension
   LogSpy logSpy = new LogSpy();

--- a/src/test/java/io/dsub/discogs/batch/util/SimpleFileUtilUnitTest.java
+++ b/src/test/java/io/dsub/discogs/batch/util/SimpleFileUtilUnitTest.java
@@ -34,20 +34,27 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class SimpleFileUtilTest {
+class SimpleFileUtilUnitTest {
 
   SimpleFileUtil fileUtil;
 
   @RegisterExtension
   LogSpy logSpy = new LogSpy();
 
+  @TempDir
+  Path tempDirectory;
+
+  String previousUserHome;
+
   @BeforeEach
   void prepare() {
+    previousUserHome = System.getProperty("user.home");
+    System.setProperty("user.home", tempDirectory.toString());
     fileUtil = spy(SimpleFileUtil.builder().appDirectory(RandomString.make()).build());
   }
 
@@ -76,6 +83,13 @@ class SimpleFileUtilTest {
       fail(e);
     } catch (NullPointerException e) {
       return;
+    } finally {
+      if (previousUserHome == null) {
+        System.clearProperty("user.home");
+      } else {
+        System.setProperty("user.home", previousUserHome);
+      }
+      fileUtil = null;
     }
   }
 
@@ -262,9 +276,7 @@ class SimpleFileUtilTest {
   }
 
   File getTemporaryFile(byte[] bytes) throws IOException {
-    TemporaryFolder folder = new TemporaryFolder();
-    folder.create();
-    File file = folder.newFile();
+    File file = Files.createTempFile(tempDirectory, "source-", ".tmp").toFile();
     if (bytes == null) {
       return file;
     }

--- a/src/test/resources/application-batch-test.yml
+++ b/src/test/resources/application-batch-test.yml
@@ -2,11 +2,3 @@ spring:
   batch:
     job:
       enabled: false
-  data:
-    jpa:
-      repositories:
-        # this is mandate as of initialization of JPA repositories
-        # may live under the process EVEN AFTER the batch job is finished.
-        # this is also can be a potential reason of spring batch not being exited
-        # immediately after the job is done.
-        bootstrap-mode: default

--- a/src/test/resources/application-test-h2.yml
+++ b/src/test/resources/application-test-h2.yml
@@ -7,10 +7,5 @@ spring:
     tomcat:
       test-while-idle: true
       validation-query: SELECT 1
-  jpa:
-    hibernate:
-      ddl-auto: update
-    generate-ddl: true
-    database-platform: org.hibernate.dialect.H2Dialect
   main:
     banner-mode: OFF

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,13 +6,5 @@ spring:
   batch:
     job:
       enabled: false
-  jpa:
-    properties:
-      hibernate:
-        jdbc:
-          # JPA_HIBERNATE_BATCH_PROPS
-          batch_size: 30 # GREATER THAN 0
-          order_inserts: true # IMPROVES RELATIONAL INSERT
-          order_updates: true # IMPROVES UPDATE RELATIONAL ENTITIES
   main:
     banner-mode: OFF


### PR DESCRIPTION
## Summary

- remove the unused Spring Data JPA dependency, Hibernate auto-configuration exclusion, and stale JPA settings
- keep database access on Spring Batch, jOOQ, Liquibase, and io.dsub.opendiscogs:open-discogs-jooq
- normalize executable test names to UnitTest, IntegrationTest, or E2ETest
- make the pull-request suite deterministic by separating external Discogs checks into the opt-in e2eTest task
- add required JaCoCo line and branch coverage gates and a GitHub Actions build
- fix JAXB runtime compatibility, isolate filesystem tests, pin the PostgreSQL test image, and bound the Discogs index lookup retries/timeouts

## Validation

- ./gradlew clean check --no-daemon
- 2,252 deterministic test cases, 0 failures
- line coverage: 2,773 / 3,090 (89.7%; required 85%)
- branch coverage: 859 / 1,888 (45.5%; required 40%)
- runtime dependency insight confirms Spring Data JPA is absent
- no JPA/Hibernate source or configuration references remain
- no GitHub token or private-key patterns were introduced

## E2E boundary

./gradlew e2eTest is intentionally separate from the deterministic pull-request gate because it calls data.discogs.com. The existing external checks are retained as E2ETest; they currently expose a pre-existing upstream index-format change and are not represented as passing in this PR.
